### PR TITLE
feat: Add test cron action and protected endpoint

### DIFF
--- a/.github/workflows/cronTest.yml
+++ b/.github/workflows/cronTest.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Invoke test
         env:
-          TEST_APP_SECRET: ${{ secrets.TEST_APP_SECRET }}
+          APP_SECRET: ${{ secrets.APP_SECRET }}
           APP_BASE_URL: ${{ secrets.BASE_URL }}
-        run: curl $APP_BASE_URL/cronTest -H "Authorization:$TEST_APP_SECRET"
+        run: curl $APP_BASE_URL/cronTest -H "Authorization:$APP_SECRET"

--- a/.github/workflows/cronTest.yml
+++ b/.github/workflows/cronTest.yml
@@ -1,0 +1,16 @@
+name: Cron Test
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # every 15 minutes
+
+jobs:
+  test-cron-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Invoke test
+        env:
+          TEST_APP_SECRET: ${{ secrets.TEST_APP_SECRET }}
+          APP_BASE_URL: ${{ secrets.BASE_URL }}
+        run: curl $APP_BASE_URL/cronTest -H "Authorization:$TEST_APP_SECRET"

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,2 +1,15 @@
+.github/
+.husky/
+.vscode/
+node_modules/
+test/
 .env
-node_modules
+.commitlintrc.json
+.editorconfig
+.eslintignore
+.eslinrc
+.prettierignore
+.prettierrc
+jest.*.ts
+LICENSE
+README.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
 # ballena-automator
 
-Automatization tasks for ballena.io
+Serverless automatization tasks for [ballena.io](https://ballena.io).
+
+## Dependencies
+
+- [Vercel CLI](https://vercel.com/download)
+  - Required to emulate local environment (serverless functions).
+
+# Development
+
+## Install requirements
+
+```shell
+yarn global add vercel
+```
+
+## Build
+
+```shell
+# Install dependencies
+yarn
+
+# Build project
+vercel dev
+```
+
+Endpoints are based on folder/filename inside the `api/` folder.
+
+```shell
+# api/time.ts
+curl -X GET 'localhost:3000/time'
+
+# ...
+```
+
+# Production
+
+## Deploy
+
+Deployments to production should be triggered by a webhook when a commit, or a pull-request is merged to `master`.
+
+If you need to force a deployment, use the following command:
+
+```shell
+vercel --prod
+```

--- a/api/cronTest.ts
+++ b/api/cronTest.ts
@@ -1,0 +1,20 @@
+import { VercelRequest, VercelResponse } from '@vercel/node'
+import { appConfig } from '../src/config'
+
+export const time = async (): Promise<{
+  time?: number
+}> => {
+  return {
+    time: new Date().getTime(),
+  }
+}
+
+export default async (req: VercelRequest, res: VercelResponse): Promise<void> => {
+  const auth = req.headers.authorization
+
+  if (auth === appConfig.secret) {
+    const data = await time()
+    res.status(200).send(data)
+  }
+  return res.status(401).end()
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,3 @@
+export const appConfig = {
+  secret: process.env.APP_SECRET,
+}


### PR DESCRIPTION
We use an APP_SECRET that should be configured on Vercel and on GitHub.

Vercel: is where the code runs, it will check if the authorization-header of the request has the correct APP_SECRET.
Environment variables: APP_SECRET

GitHub: is where the call originates, from an scheduled workflow action.
Environment variables: BASE_URL (url of deployed endpoint), APP_SECRET (same token from Vercel's APP_SECRET)
